### PR TITLE
Fix unstable batch exports on larger processes

### DIFF
--- a/index.html
+++ b/index.html
@@ -857,6 +857,7 @@
 
 <script type="text/javascript" src="javascripts/filedrop.js"></script>
 <script type="text/javascript" src="javascripts/filters.js"></script>
+<script type="text/javascript" src="javascripts/renderTargetUtils.js"></script>
 <script type="text/javascript" src="javascripts/renderView.js"></script>
 <script type="text/javascript" src="javascripts/renderNormalview.js"></script>
 <script type="text/javascript" src="javascripts/normalMap.js"></script>

--- a/javascripts/ambientOccMap.js
+++ b/javascripts/ambientOccMap.js
@@ -57,6 +57,13 @@ NMO_AmbientOccMap = new function(){
 	this.height_map_tex;
 	this.gaussian_shader_y, this.gaussian_shader_x;
 
+	this.disposeRenderTarget = function(){
+		if (this.renderTarget){
+			this.renderTarget.dispose();
+			this.renderTarget = null;
+		}
+	};
+
 	this.createAmbientOcclusionTexture = function(){
 		this.createGPUbasedAOTexture();
 		return;
@@ -154,6 +161,7 @@ NMO_AmbientOccMap = new function(){
 		this.renderer.setSize( w, h );
 		this.composer.setSize( w, h );
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
+		this.disposeRenderTarget();
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer.reset(this.renderTarget);
 		this.composer.render( 1 / 60 );
@@ -222,6 +230,7 @@ NMO_AmbientOccMap = new function(){
 		
 		
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
+		this.disposeRenderTarget();
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer = new THREE.EffectComposer( this.renderer, this.renderTarget );
 		//renderer_aomap.render( scene_aomap, camera_aomap, renderTarget );

--- a/javascripts/ambientOccMap.js
+++ b/javascripts/ambientOccMap.js
@@ -56,13 +56,7 @@ NMO_AmbientOccMap = new function(){
 	this.uniforms;
 	this.height_map_tex;
 	this.gaussian_shader_y, this.gaussian_shader_x;
-
-	this.disposeRenderTarget = function(){
-		if (this.renderTarget){
-			this.renderTarget.dispose();
-			this.renderTarget = null;
-		}
-	};
+	this.renderTarget;
 
 	this.createAmbientOcclusionTexture = function(){
 		this.createGPUbasedAOTexture();
@@ -161,7 +155,7 @@ NMO_AmbientOccMap = new function(){
 		this.renderer.setSize( w, h );
 		this.composer.setSize( w, h );
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-		this.disposeRenderTarget();
+		NMO_RenderTargetUtils.disposeRenderTarget(this);
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer.reset(this.renderTarget);
 		this.composer.render( 1 / 60 );
@@ -230,7 +224,7 @@ NMO_AmbientOccMap = new function(){
 		
 		
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-		this.disposeRenderTarget();
+		NMO_RenderTargetUtils.disposeRenderTarget(this);
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer = new THREE.EffectComposer( this.renderer, this.renderTarget );
 		//renderer_aomap.render( scene_aomap, camera_aomap, renderTarget );

--- a/javascripts/displaceMap.js
+++ b/javascripts/displaceMap.js
@@ -49,6 +49,13 @@ NMO_DisplacementMap = new function(){
 	this.height_map_tex;
 	this.gaussian_shader_y, this.gaussian_shader_x;
 
+	this.disposeRenderTarget = function(){
+		if (this.renderTarget){
+			this.renderTarget.dispose();
+			this.renderTarget = null;
+		}
+	};
+
 	this.createDisplacementMap = function(){
 		this.createGPUbasedDisplacementTexture();
 			
@@ -158,6 +165,7 @@ NMO_DisplacementMap = new function(){
 		this.renderer.setSize( w, h );
 		this.composer.setSize( w, h );
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
+		this.disposeRenderTarget();
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer.reset(this.renderTarget);
 		this.composer.render( 1 / 60 );
@@ -222,8 +230,9 @@ NMO_DisplacementMap = new function(){
 		
 		
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
+		this.disposeRenderTarget();
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
-		this.composer = new THREE.EffectComposer( this.renderer, renderTarget );
+		this.composer = new THREE.EffectComposer( this.renderer, this.renderTarget );
 		//renderer_aomap.render( scene_aomap, camera_aomap, renderTarget );
 		//renderer_aomap.render( scene_aomap, camera_aomap );
 		//this.composer_aomap.setSize( w, h );

--- a/javascripts/displaceMap.js
+++ b/javascripts/displaceMap.js
@@ -48,13 +48,7 @@ NMO_DisplacementMap = new function(){
 	this.uniforms;
 	this.height_map_tex;
 	this.gaussian_shader_y, this.gaussian_shader_x;
-
-	this.disposeRenderTarget = function(){
-		if (this.renderTarget){
-			this.renderTarget.dispose();
-			this.renderTarget = null;
-		}
-	};
+	this.renderTarget;
 
 	this.createDisplacementMap = function(){
 		this.createGPUbasedDisplacementTexture();
@@ -165,7 +159,7 @@ NMO_DisplacementMap = new function(){
 		this.renderer.setSize( w, h );
 		this.composer.setSize( w, h );
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-		this.disposeRenderTarget();
+		NMO_RenderTargetUtils.disposeRenderTarget(this);
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer.reset(this.renderTarget);
 		this.composer.render( 1 / 60 );
@@ -230,7 +224,7 @@ NMO_DisplacementMap = new function(){
 		
 		
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-		this.disposeRenderTarget();
+		NMO_RenderTargetUtils.disposeRenderTarget(this);
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer = new THREE.EffectComposer( this.renderer, this.renderTarget );
 		//renderer_aomap.render( scene_aomap, camera_aomap, renderTarget );

--- a/javascripts/filedrop.js
+++ b/javascripts/filedrop.js
@@ -122,26 +122,6 @@ NMO_FileDrop = new function(){
 	    NMO_FileDrop.readModelFile(evt.target.files[0]); // files is a FileList of File objects. List some properties.
 	}
 
-	this.isSupportedImageFile = function(imgFile){
-		const fileType = (imgFile.type || "").toLowerCase();
-		const fileName = (imgFile.name || "").toLowerCase();
-
-		if (fileType.match(/image.*/))
-			return true;
-
-		return /\.(png|jpe?g|bmp|gif|webp|tga)$/i.test(fileName);
-	};
-
-	this.isTargaFile = function(imgFile){
-		const fileType = (imgFile.type || "").toLowerCase();
-		const fileName = (imgFile.name || "").toLowerCase();
-
-		return fileType == "image/targa" ||
-			fileType == "image/x-targa" ||
-			fileType == "image/x-tga" ||
-			/\.tga$/i.test(fileName);
-	};
-
 	this.readModelFile = function(file){
 		console.log(file);
 		console.log("trying to load model")
@@ -186,14 +166,14 @@ NMO_FileDrop = new function(){
 
 	this.readImage = async function(imgFile, type, direction, readImageCallback=false, name=""){
 		//console.log(imgFile);
-		if(!this.isSupportedImageFile(imgFile))
+		if(!imgFile.type.match(/image.*/))
 		{
-			console.log("The dropped file is not an image: ", imgFile.type || imgFile.name);
+			console.log("The dropped file is not an image: ", imgFile.type);
 			return;
 		}
-		console.log("Loading " + (imgFile.type || imgFile.name) + " image");
+		console.log("Loading " + imgFile.type + " image");
 
-		let isTarga = this.isTargaFile(imgFile);
+		let isTarga = imgFile.type == "image/targa" || imgFile.type == "image/x-targa" || imgFile.type == "image/x-tga";
 
 		const data = await new Promise((resolve, reject) => {
 			const reader = new FileReader();

--- a/javascripts/filedrop.js
+++ b/javascripts/filedrop.js
@@ -63,31 +63,39 @@ NMO_FileDrop = new function(){
 		const includeDisplacement = document.getElementById('displacement_tick').checked;
 		const includeAmbient = document.getElementById('ambient_tick').checked;
 		const includeSpecular = document.getElementById('specular_tick').checked;
+		const fileNameInput = document.getElementById('file_name');
+		const batchInput = document.getElementById('select_multiple_height_files');
+		const originalFileName = fileNameInput.value;
+		const selectedMaps = [];
 
-		for (let i = 0; i < files.length; i++) {
-			await this.readImage(files[i], "height", "", async (name) => {
-				const baseName = name.replace(/\.[^/.]+$/, "");
-				
-				if (includeNormal) {
-					document.getElementById('file_name').value = `${baseName}_normal`;
-					await NMO_Main.downloadImage("NormalMap");
-				}
-				
-				if (includeDisplacement) {
-					document.getElementById('file_name').value = `${baseName}_displacement`;
-					await NMO_Main.downloadImage("DisplacementMap");
-				}
-				
-				if (includeAmbient) {
-					document.getElementById('file_name').value = `${baseName}_ambient`;
-					await NMO_Main.downloadImage("AmbientOcclusionMap");
-				}
-				
-				if (includeSpecular) {
-					document.getElementById('file_name').value = `${baseName}_specular`;
-					await NMO_Main.downloadImage("SpecularMap");
-				}
-			}, files[i].name);
+		if (includeNormal)
+			selectedMaps.push({ type: "NormalMap", suffix: "normal" });
+		if (includeDisplacement)
+			selectedMaps.push({ type: "DisplacementMap", suffix: "displacement" });
+		if (includeAmbient)
+			selectedMaps.push({ type: "AmbientOcclusionMap", suffix: "ambient" });
+		if (includeSpecular)
+			selectedMaps.push({ type: "SpecularMap", suffix: "specular" });
+
+		if (selectedMaps.length === 0)
+			return;
+
+		try {
+			for (let i = 0; i < files.length; i++) {
+				await this.readImage(files[i], "height", "", async (name) => {
+					const baseName = name.replace(/\.[^/.]+$/, "");
+
+					for (let mapIndex = 0; mapIndex < selectedMaps.length; mapIndex++) {
+						const map = selectedMaps[mapIndex];
+						fileNameInput.value = `${baseName}_${map.suffix}`;
+						await NMO_Main.downloadImage(map.type);
+					}
+				}, files[i].name);
+			}
+		}
+		finally {
+			fileNameInput.value = originalFileName;
+			batchInput.value = "";
 		}
 	};
 
@@ -113,6 +121,26 @@ NMO_FileDrop = new function(){
 	    var files = evt.target.files; // FileList object
 	    NMO_FileDrop.readModelFile(evt.target.files[0]); // files is a FileList of File objects. List some properties.
 	}
+
+	this.isSupportedImageFile = function(imgFile){
+		const fileType = (imgFile.type || "").toLowerCase();
+		const fileName = (imgFile.name || "").toLowerCase();
+
+		if (fileType.match(/image.*/))
+			return true;
+
+		return /\.(png|jpe?g|bmp|gif|webp|tga)$/i.test(fileName);
+	};
+
+	this.isTargaFile = function(imgFile){
+		const fileType = (imgFile.type || "").toLowerCase();
+		const fileName = (imgFile.name || "").toLowerCase();
+
+		return fileType == "image/targa" ||
+			fileType == "image/x-targa" ||
+			fileType == "image/x-tga" ||
+			/\.tga$/i.test(fileName);
+	};
 
 	this.readModelFile = function(file){
 		console.log(file);
@@ -158,14 +186,14 @@ NMO_FileDrop = new function(){
 
 	this.readImage = async function(imgFile, type, direction, readImageCallback=false, name=""){
 		//console.log(imgFile);
-		if(!imgFile.type.match(/image.*/))
+		if(!this.isSupportedImageFile(imgFile))
 		{
-			console.log("The dropped file is not an image: ", imgFile.type);
+			console.log("The dropped file is not an image: ", imgFile.type || imgFile.name);
 			return;
 		}
-		console.log("Loading " + imgFile.type + " image");
+		console.log("Loading " + (imgFile.type || imgFile.name) + " image");
 
-		let isTarga = imgFile.type == "image/targa" || imgFile.type == "image/x-targa" || imgFile.type == "image/x-tga";
+		let isTarga = this.isTargaFile(imgFile);
 
 		const data = await new Promise((resolve, reject) => {
 			const reader = new FileReader();

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -316,14 +316,14 @@ var NMO_Main = new function(){
 		await this.wait(150);
 	};
 
-	this.download_all_btn.addEventListener('click', async function (e) {		
+	this.download_all_btn.addEventListener('click', async function (e) {
 		await NMO_Main.downloadImage("NormalMap");
 		await NMO_Main.downloadImage("DisplacementMap");
 		await NMO_Main.downloadImage("AmbientOcclusionMap");
 		await NMO_Main.downloadImage("SpecularMap");
 	});
 	
-	this.download_btn.addEventListener('click', function (e) {		
+	this.download_btn.addEventListener('click', function (e) {
 		if (document.getElementById('normal_map').style.cssText != "display: none;"){
 			NMO_Main.downloadImage("NormalMap");
 		}
@@ -339,79 +339,82 @@ var NMO_Main = new function(){
 	});
 	
 	
-	this.downloadImage = function(type){
-		return new Promise(function(resolve, reject){
-			console.log("Downloading image");
-			var file_name = "download";
-			var canvas = document.createElement("canvas");
-			
-			var file_type = NMO_Main.getImageType();
-			var image_type = "image/png";
-			if (file_type == "jpg")
-				image_type = "image/jpeg";
+	this.downloadImage = async function(type){
+		console.log("Downloading image");
+		var file_name = "download";
+		var canvas = document.createElement("canvas");
 
-			if (type == "NormalMap"){
-				canvas.width = NMO_NormalMap.normal_canvas.width;
-				canvas.height = NMO_NormalMap.normal_canvas.height;
-				var context = canvas.getContext('2d');
-				if (file_type == "png") 
-					context.globalAlpha = $('#transparency_nmb').val() / 100;
-				context.drawImage(NMO_NormalMap.normal_canvas,0,0);
-				file_name="NormalMap";
-			}
-			else if (type == "DisplacementMap"){
-				canvas.width = NMO_DisplacementMap.displacement_canvas.width;
-				canvas.height = NMO_DisplacementMap.displacement_canvas.height;
-				var context = canvas.getContext('2d');
-				if (file_type == "png") 
-					context.globalAlpha = $('#transparency_nmb').val() / 100;
-				context.drawImage(NMO_DisplacementMap.displacement_canvas,0,0);
-				file_name="DisplacementMap";
-			}
-			else if (type == "AmbientOcclusionMap"){
-				canvas.width = NMO_AmbientOccMap.ao_canvas.width;
-				canvas.height = NMO_AmbientOccMap.ao_canvas.height;
-				var context = canvas.getContext('2d');
-				if (file_type == "png") 
-					context.globalAlpha = $('#transparency_nmb').val() / 100;
-				context.drawImage(NMO_AmbientOccMap.ao_canvas,0,0);
-				file_name="AmbientOcclusionMap";
-			}
-			else if (type == "SpecularMap"){
-				canvas.width = NMO_SpecularMap.specular_canvas.width;
-				canvas.height = NMO_SpecularMap.specular_canvas.height;
-				var context = canvas.getContext('2d');
-				if (file_type == "png") 
-					context.globalAlpha = $('#transparency_nmb').val() / 100;
-				context.drawImage(NMO_SpecularMap.specular_canvas,0,0);
-				file_name="SpecularMap";
-			}
-			
-			if (document.getElementById('file_name').value != "")
-				file_name = document.getElementById('file_name').value;
-			
-			var qual = $('#file_jpg_qual_nmb').val() / 100;
+		var file_type = NMO_Main.getImageType();
+		var image_type = "image/png";
+		if (file_type == "jpg")
+			image_type = "image/jpeg";
+
+		if (type == "NormalMap"){
+			canvas.width = NMO_NormalMap.normal_canvas.width;
+			canvas.height = NMO_NormalMap.normal_canvas.height;
+			var context = canvas.getContext('2d');
+			if (file_type == "png")
+				context.globalAlpha = $('#transparency_nmb').val() / 100;
+			context.drawImage(NMO_NormalMap.normal_canvas,0,0);
+			file_name="NormalMap";
+		}
+		else if (type == "DisplacementMap"){
+			canvas.width = NMO_DisplacementMap.displacement_canvas.width;
+			canvas.height = NMO_DisplacementMap.displacement_canvas.height;
+			var context = canvas.getContext('2d');
+			if (file_type == "png")
+				context.globalAlpha = $('#transparency_nmb').val() / 100;
+			context.drawImage(NMO_DisplacementMap.displacement_canvas,0,0);
+			file_name="DisplacementMap";
+		}
+		else if (type == "AmbientOcclusionMap"){
+			canvas.width = NMO_AmbientOccMap.ao_canvas.width;
+			canvas.height = NMO_AmbientOccMap.ao_canvas.height;
+			var context = canvas.getContext('2d');
+			if (file_type == "png")
+				context.globalAlpha = $('#transparency_nmb').val() / 100;
+			context.drawImage(NMO_AmbientOccMap.ao_canvas,0,0);
+			file_name="AmbientOcclusionMap";
+		}
+		else if (type == "SpecularMap"){
+			canvas.width = NMO_SpecularMap.specular_canvas.width;
+			canvas.height = NMO_SpecularMap.specular_canvas.height;
+			var context = canvas.getContext('2d');
+			if (file_type == "png")
+				context.globalAlpha = $('#transparency_nmb').val() / 100;
+			context.drawImage(NMO_SpecularMap.specular_canvas,0,0);
+			file_name="SpecularMap";
+		}
+
+		if (document.getElementById('file_name').value != "")
+			file_name = document.getElementById('file_name').value;
+
+		var qual = $('#file_jpg_qual_nmb').val() / 100;
+		var blob = await new Promise(function(resolve, reject) {
 			if (file_type == "tiff"){
-				CanvasToTIFF.toBlob(canvas, async function(blob) {
-	   				if (!blob){
-	   					reject(new Error("Could not create TIFF blob."));
-	   					return;
-	   				}
-	   				await NMO_Main.finishDownload(blob, file_name + ".tif");
-	   				resolve();
+				CanvasToTIFF.toBlob(canvas, function(generatedBlob) {
+					if (!generatedBlob){
+						reject(new Error("Could not create TIFF blob."));
+						return;
+					}
+					resolve(generatedBlob);
 			    });
 			}
 			else{
-				canvas.toBlob(async function(blob) {
-					if (!blob){
+				canvas.toBlob(function(generatedBlob) {
+					if (!generatedBlob){
 						reject(new Error("Could not create image blob."));
 						return;
 					}
-	    			await NMO_Main.finishDownload(blob, file_name + "." + file_type);
-	    			resolve();
+					resolve(generatedBlob);
 				}, image_type, qual);
 			}
 		});
+
+		if (file_type == "tiff")
+			await NMO_Main.finishDownload(blob, file_name + ".tif");
+		else
+			await NMO_Main.finishDownload(blob, file_name + "." + file_type);
 	}
 
 	this.resetNormalMapSettings = function() {

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -304,11 +304,23 @@ var NMO_Main = new function(){
 			NMO_SpecularMap.createSpecularTexture();
 	};
 
-	this.download_all_btn.addEventListener('click', function (e) {		
-		NMO_Main.downloadImage("NormalMap");
-		NMO_Main.downloadImage("DisplacementMap");
-		NMO_Main.downloadImage("AmbientOcclusionMap");
-		NMO_Main.downloadImage("SpecularMap");
+	this.wait = function(ms){
+		return new Promise(function(resolve){
+			setTimeout(resolve, ms);
+		});
+	};
+
+	this.finishDownload = async function(blob, file_name){
+		saveAs(blob, file_name);
+		// Give the browser a moment to register each programmatic save before the next one.
+		await this.wait(150);
+	};
+
+	this.download_all_btn.addEventListener('click', async function (e) {		
+		await NMO_Main.downloadImage("NormalMap");
+		await NMO_Main.downloadImage("DisplacementMap");
+		await NMO_Main.downloadImage("AmbientOcclusionMap");
+		await NMO_Main.downloadImage("SpecularMap");
 	});
 	
 	this.download_btn.addEventListener('click', function (e) {		
@@ -328,69 +340,78 @@ var NMO_Main = new function(){
 	
 	
 	this.downloadImage = function(type){
-		console.log("Downloading image");
-		var qual = 0.9;
-		var file_name = "download";
-		var canvas = document.createElement("canvas");
-		
-		var file_type = NMO_Main.getImageType();
-		var image_type = "image/png";
-		if (file_type == "jpg")
-			image_type = "image/jpeg";
-
-		if (type == "NormalMap"){
-			canvas.width = NMO_NormalMap.normal_canvas.width;
-			canvas.height = NMO_NormalMap.normal_canvas.height;
-			var context = canvas.getContext('2d');
-			if (file_type == "png") 
-				context.globalAlpha = $('#transparency_nmb').val() / 100;
-			context.drawImage(NMO_NormalMap.normal_canvas,0,0);
-			file_name="NormalMap";
-		}
-		else if (type == "DisplacementMap"){
-			canvas.width = NMO_DisplacementMap.displacement_canvas.width;
-			canvas.height = NMO_DisplacementMap.displacement_canvas.height;
-			var context = canvas.getContext('2d');
-			if (file_type == "png") 
-				context.globalAlpha = $('#transparency_nmb').val() / 100;
-			context.drawImage(NMO_DisplacementMap.displacement_canvas,0,0);
-			file_name="DisplacementMap";
-		}
-		else if (type == "AmbientOcclusionMap"){
-			canvas.width = NMO_AmbientOccMap.ao_canvas.width;
-			canvas.height = NMO_AmbientOccMap.ao_canvas.height;
-			var context = canvas.getContext('2d');
-			if (file_type == "png") 
-				context.globalAlpha = $('#transparency_nmb').val() / 100;
-			context.drawImage(NMO_AmbientOccMap.ao_canvas,0,0);
-			file_name="AmbientOcclusionMap";
-		}
-		else if (type == "SpecularMap"){
-			canvas.width = NMO_SpecularMap.specular_canvas.width;
-			canvas.height = NMO_SpecularMap.specular_canvas.height;
-			var context = canvas.getContext('2d');
-			if (file_type == "png") 
-				context.globalAlpha = $('#transparency_nmb').val() / 100;
-			context.drawImage(NMO_SpecularMap.specular_canvas,0,0);
-			file_name="SpecularMap";
-		}
-		
-		if (document.getElementById('file_name').value != "")
-			file_name = document.getElementById('file_name').value;
-		
-		
+		return new Promise(function(resolve, reject){
+			console.log("Downloading image");
+			var file_name = "download";
+			var canvas = document.createElement("canvas");
 			
-		var qual = $('#file_jpg_qual_nmb').val() / 100;
-		if (file_type == "tiff"){
-			CanvasToTIFF.toBlob(canvas, function(blob) {
-   				saveAs(blob, file_name + ".tif");
-		    });
-		}
-		else{
-			canvas.toBlob(function(blob) {
-	    		saveAs(blob, file_name + "." + file_type);
-			}, image_type, qual);
-		}
+			var file_type = NMO_Main.getImageType();
+			var image_type = "image/png";
+			if (file_type == "jpg")
+				image_type = "image/jpeg";
+
+			if (type == "NormalMap"){
+				canvas.width = NMO_NormalMap.normal_canvas.width;
+				canvas.height = NMO_NormalMap.normal_canvas.height;
+				var context = canvas.getContext('2d');
+				if (file_type == "png") 
+					context.globalAlpha = $('#transparency_nmb').val() / 100;
+				context.drawImage(NMO_NormalMap.normal_canvas,0,0);
+				file_name="NormalMap";
+			}
+			else if (type == "DisplacementMap"){
+				canvas.width = NMO_DisplacementMap.displacement_canvas.width;
+				canvas.height = NMO_DisplacementMap.displacement_canvas.height;
+				var context = canvas.getContext('2d');
+				if (file_type == "png") 
+					context.globalAlpha = $('#transparency_nmb').val() / 100;
+				context.drawImage(NMO_DisplacementMap.displacement_canvas,0,0);
+				file_name="DisplacementMap";
+			}
+			else if (type == "AmbientOcclusionMap"){
+				canvas.width = NMO_AmbientOccMap.ao_canvas.width;
+				canvas.height = NMO_AmbientOccMap.ao_canvas.height;
+				var context = canvas.getContext('2d');
+				if (file_type == "png") 
+					context.globalAlpha = $('#transparency_nmb').val() / 100;
+				context.drawImage(NMO_AmbientOccMap.ao_canvas,0,0);
+				file_name="AmbientOcclusionMap";
+			}
+			else if (type == "SpecularMap"){
+				canvas.width = NMO_SpecularMap.specular_canvas.width;
+				canvas.height = NMO_SpecularMap.specular_canvas.height;
+				var context = canvas.getContext('2d');
+				if (file_type == "png") 
+					context.globalAlpha = $('#transparency_nmb').val() / 100;
+				context.drawImage(NMO_SpecularMap.specular_canvas,0,0);
+				file_name="SpecularMap";
+			}
+			
+			if (document.getElementById('file_name').value != "")
+				file_name = document.getElementById('file_name').value;
+			
+			var qual = $('#file_jpg_qual_nmb').val() / 100;
+			if (file_type == "tiff"){
+				CanvasToTIFF.toBlob(canvas, async function(blob) {
+	   				if (!blob){
+	   					reject(new Error("Could not create TIFF blob."));
+	   					return;
+	   				}
+	   				await NMO_Main.finishDownload(blob, file_name + ".tif");
+	   				resolve();
+			    });
+			}
+			else{
+				canvas.toBlob(async function(blob) {
+					if (!blob){
+						reject(new Error("Could not create image blob."));
+						return;
+					}
+	    			await NMO_Main.finishDownload(blob, file_name + "." + file_type);
+	    			resolve();
+				}, image_type, qual);
+			}
+		});
 	}
 
 	this.resetNormalMapSettings = function() {

--- a/javascripts/renderNormalview.js
+++ b/javascripts/renderNormalview.js
@@ -46,13 +46,6 @@ var NMO_RenderNormalview = new function(){
 		this.composer_Normalview.render( 1 / 60 );		
 	};
 
-	this.disposeRenderTarget = function() {
-		if (this.renderTarget){
-			this.renderTarget.dispose();
-			this.renderTarget = null;
-		}
-	};
-
 	this.renderNormalview_init = function() {
 		
 		this.renderer_Normalview = new THREE.WebGLRenderer({ alpha: true, antialias: true, canvas: NMO_NormalMap.normal_canvas });
@@ -157,7 +150,7 @@ var NMO_RenderNormalview = new function(){
 		//composer_Normalview.addPass( copyPass );
 
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-		this.disposeRenderTarget();
+		NMO_RenderTargetUtils.disposeRenderTarget(this);
 		this.renderTarget = new THREE.WebGLRenderTarget( NMO_FileDrop.height_image.width, NMO_FileDrop.height_image.height, renderTargetParameters );
 		this.composer_Normalview = new THREE.EffectComposer( this.renderer_Normalview, this.renderTarget );
 		this.composer_Normalview.setSize( NMO_FileDrop.height_image.width, NMO_FileDrop.height_image.height );
@@ -225,7 +218,7 @@ var NMO_RenderNormalview = new function(){
 			this.renderer_Normalview.setSize( img.naturalWidth, img.naturalHeight );
 			this.composer_Normalview.setSize( img.naturalWidth, img.naturalHeight );
 			var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-			this.disposeRenderTarget();
+			NMO_RenderTargetUtils.disposeRenderTarget(this);
 			this.renderTarget = new THREE.WebGLRenderTarget( img.width, img.height, renderTargetParameters );
 			this.composer_Normalview.reset(this.renderTarget);
 		}
@@ -250,7 +243,7 @@ var NMO_RenderNormalview = new function(){
 			this.renderer_Normalview.setSize( img.naturalWidth, img.naturalHeight );
 			this.composer_Normalview.setSize( img.naturalWidth, img.naturalHeight );
 			var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-			this.disposeRenderTarget();
+			NMO_RenderTargetUtils.disposeRenderTarget(this);
 			this.renderTarget = new THREE.WebGLRenderTarget( img.width, img.height, renderTargetParameters );
 			this.composer_Normalview.reset(this.renderTarget);
 

--- a/javascripts/renderNormalview.js
+++ b/javascripts/renderNormalview.js
@@ -26,6 +26,7 @@ var NMO_RenderNormalview = new function(){
 
 	this.renderer_Normalview;
 	this.composer_Normalview;
+	this.renderTarget;
 	this.scene_Normalview;
 	this.camera_Normalview;
 	this.gaussian_shader_y, this.gaussian_shader_x, this.gaussian_shader;
@@ -43,6 +44,13 @@ var NMO_RenderNormalview = new function(){
 
 	this.renderNormalView = function() {
 		this.composer_Normalview.render( 1 / 60 );		
+	};
+
+	this.disposeRenderTarget = function() {
+		if (this.renderTarget){
+			this.renderTarget.dispose();
+			this.renderTarget = null;
+		}
 	};
 
 	this.renderNormalview_init = function() {
@@ -149,8 +157,9 @@ var NMO_RenderNormalview = new function(){
 		//composer_Normalview.addPass( copyPass );
 
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-		renderTarget = new THREE.WebGLRenderTarget( NMO_FileDrop.height_image.width, NMO_FileDrop.height_image.height, renderTargetParameters );
-		this.composer_Normalview = new THREE.EffectComposer( this.renderer_Normalview, renderTarget );
+		this.disposeRenderTarget();
+		this.renderTarget = new THREE.WebGLRenderTarget( NMO_FileDrop.height_image.width, NMO_FileDrop.height_image.height, renderTargetParameters );
+		this.composer_Normalview = new THREE.EffectComposer( this.renderer_Normalview, this.renderTarget );
 		this.composer_Normalview.setSize( NMO_FileDrop.height_image.width, NMO_FileDrop.height_image.height );
 		this.composer_Normalview.addPass( this.NormalRenderScene );
 		this.composer_Normalview.addPass( this.gaussian_shader_y );	
@@ -216,8 +225,9 @@ var NMO_RenderNormalview = new function(){
 			this.renderer_Normalview.setSize( img.naturalWidth, img.naturalHeight );
 			this.composer_Normalview.setSize( img.naturalWidth, img.naturalHeight );
 			var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-			renderTarget = new THREE.WebGLRenderTarget( img.width, img.height, renderTargetParameters );
-			this.composer_Normalview.reset(renderTarget);
+			this.disposeRenderTarget();
+			this.renderTarget = new THREE.WebGLRenderTarget( img.width, img.height, renderTargetParameters );
+			this.composer_Normalview.reset(this.renderTarget);
 		}
 
 		else if (map === "pictures"){
@@ -240,8 +250,9 @@ var NMO_RenderNormalview = new function(){
 			this.renderer_Normalview.setSize( img.naturalWidth, img.naturalHeight );
 			this.composer_Normalview.setSize( img.naturalWidth, img.naturalHeight );
 			var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-			renderTarget = new THREE.WebGLRenderTarget( img.width, img.height, renderTargetParameters );
-			this.composer_Normalview.reset(renderTarget);
+			this.disposeRenderTarget();
+			this.renderTarget = new THREE.WebGLRenderTarget( img.width, img.height, renderTargetParameters );
+			this.composer_Normalview.reset(this.renderTarget);
 
 			this.picture_above_map.needsUpdate = true;
 			this.picture_left_map.needsUpdate = true;

--- a/javascripts/renderTargetUtils.js
+++ b/javascripts/renderTargetUtils.js
@@ -1,0 +1,31 @@
+/*
+ * Author: Christian Petry
+ * Homepage: www.petry-christian.de
+ *
+ * License: MIT
+ * Copyright (c) 2014 Christian Petry
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+var NMO_RenderTargetUtils = new function(){
+	this.disposeRenderTarget = function(instance){
+		if (instance.renderTarget){
+			instance.renderTarget.dispose();
+			instance.renderTarget = null;
+		}
+	};
+}

--- a/javascripts/specularMap.js
+++ b/javascripts/specularMap.js
@@ -58,13 +58,7 @@ NMO_SpecularMap = new function(){
 	this.uniforms;
 	this.height_map_tex;
 	this.gaussian_shader_y, this.gaussian_shader_x;
-
-	this.disposeRenderTarget = function(){
-		if (this.renderTarget){
-			this.renderTarget.dispose();
-			this.renderTarget = null;
-		}
-	};
+	this.renderTarget;
 
 	this.setSpecularSetting = function(element, v){
 		if (element == "spec_strength")
@@ -184,7 +178,7 @@ NMO_SpecularMap = new function(){
 		this.renderer.setSize( w, h );
 		this.composer.setSize( w, h );
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-		this.disposeRenderTarget();
+		NMO_RenderTargetUtils.disposeRenderTarget(this);
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer.reset(this.renderTarget);
 		this.composer.render( 1 / 60 );
@@ -254,7 +248,7 @@ NMO_SpecularMap = new function(){
 		
 		
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
-		this.disposeRenderTarget();
+		NMO_RenderTargetUtils.disposeRenderTarget(this);
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer = new THREE.EffectComposer( this.renderer, this.renderTarget );
 		//this.renderer.render( scene, camera, this.renderTarget );

--- a/javascripts/specularMap.js
+++ b/javascripts/specularMap.js
@@ -59,6 +59,13 @@ NMO_SpecularMap = new function(){
 	this.height_map_tex;
 	this.gaussian_shader_y, this.gaussian_shader_x;
 
+	this.disposeRenderTarget = function(){
+		if (this.renderTarget){
+			this.renderTarget.dispose();
+			this.renderTarget = null;
+		}
+	};
+
 	this.setSpecularSetting = function(element, v){
 		if (element == "spec_strength")
 			this.specular_strength = v;
@@ -177,6 +184,7 @@ NMO_SpecularMap = new function(){
 		this.renderer.setSize( w, h );
 		this.composer.setSize( w, h );
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
+		this.disposeRenderTarget();
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer.reset(this.renderTarget);
 		this.composer.render( 1 / 60 );
@@ -246,6 +254,7 @@ NMO_SpecularMap = new function(){
 		
 		
 		var renderTargetParameters = { minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, format: THREE.RGBAFormat, stencilBufer: false };
+		this.disposeRenderTarget();
 		this.renderTarget = new THREE.WebGLRenderTarget( w, h, renderTargetParameters );
 		this.composer = new THREE.EffectComposer( this.renderer, this.renderTarget );
 		//this.renderer.render( scene, camera, this.renderTarget );


### PR DESCRIPTION
Batch mode was not reliably exporting all selected files. The download path fired multiple async saves without actually waiting for completion, so browsers would only allow some of the downloads through. The render pipeline was also creating new WebGL render targets during repeated batch processing without disposing old ones, which made larger batches increasingly unstable.

This PR:
- makes batch downloads run sequentially
- improves file detection for image uploads, including TGA by extension
- disposes old WebGL render targets during regeneration to keep batch processing stable